### PR TITLE
Make MySQL go faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN \
       echo '[mysqld]'; \
       echo 'user = mysql'; \
       echo 'datadir = /var/lib/mysql'; \
+      echo 'innodb_flush_log_at_trx_commit = 0'; \
+      echo 'innodb_doublewrite = 0'; \
     } > /etc/mysql/conf.d/docker.cnf
 
 RUN \


### PR DESCRIPTION
Inspired by: http://www.tocker.ca/2013/11/04/reducing-mysql-durability-for-testing.html

Since we don't care about durability in test envrionments, lets turn the knobs.